### PR TITLE
#5 tfstateファイルをGCSに保管する

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -7,6 +7,11 @@ terraform {
       version = "~> 4.0"
     }
   }
+
+  backend "gcs" {
+    bucket  = "058269-tfstate"
+    prefix  = "terraform/state"
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
## Issue

* #5 

## やったこと

* backendでGCSバケットにtfstateファイルを保管するよう指定。