### PR TITLE
#6 terraform-docsを導入する

### DIFF
--- a/.github/workflows/generate_terraform-docs.yml
+++ b/.github/workflows/generate_terraform-docs.yml
@@ -1,0 +1,19 @@
+name: Generate terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@main
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # terraform-deploy-to-gcp
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.5.7 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.82.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_storage_bucket.tfstate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_labels"></a> [labels](#input\_labels) | Managed by terraform. | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Issue

* #6 

## やったこと

* [terraform-docs](https://terraform-docs.io/)を用いて`README.md`を更新。
* PR関連のイベントをトリガーとして、GitHub Actionsワークフローで自動でterraform-docsを作成する。

### コマンド
```sh
# brewでterraform-docsをインストール
brew install terraform-docs

# inject(挿入モード)でREADME.mdを作成
terraform-docs markdown table --output-file README.md --output-mode inject .
```

## できるようになること

* README.mdがリソース構成に合わせて自動更新される。